### PR TITLE
2to3 conversion, manual sync of fixes from upstream egh/spydaap

### DIFF
--- a/run_spydaap
+++ b/run_spydaap
@@ -1,3 +1,3 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 from spydaap import cli
 cli.main()

--- a/spydaap/__init__.py
+++ b/spydaap/__init__.py
@@ -14,7 +14,7 @@
 # along with Spydaap. If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import playlists
+import spydaap.playlists
 import spydaap.parser.mp3
 import spydaap.parser.ogg
 import spydaap.parser.flac
@@ -48,7 +48,7 @@ class ContentRangeFile(object):
     def __len__(self):
         return self.length
 
-    def next(self):
+    def __next__(self):
         to_read = self.chunk
         if (self.end is not None):
             if (self.read >= self.end):

--- a/spydaap/cache.py
+++ b/spydaap/cache.py
@@ -51,7 +51,7 @@ class OrderedCache(object):
         def __iter__(self):
             return self
 
-        def next(self):
+        def __next__(self):
             if self.n >= len(self.cache):
                 raise StopIteration
             self.n = self.n + 1

--- a/spydaap/daap.py
+++ b/spydaap/daap.py
@@ -185,7 +185,7 @@ class DAAPObject(object):
             elif self.type == 't':
                 packing = 'I'
             elif self.type == 's':
-                if isinstance(value, unicode):
+                if isinstance(value, str):
                     value = value.encode('utf-8')
                 packing = '%ss' % len(value)
             else:
@@ -259,11 +259,11 @@ class DAAPObject(object):
             # the object is a string
             # we need to read length characters from the string
             try:
-                self.value = unicode(
+                self.value = str(
                     struct.unpack('!%ss' % self.length, code)[0], 'utf-8')
             except UnicodeDecodeError:
                 # oh, urgh
-                self.value = unicode(
+                self.value = str(
                     struct.unpack('!%ss' % self.length, code)[0], 'latin-1')
         else:
             # we don't know what to do with this object

--- a/spydaap/daap_data.py
+++ b/spydaap/daap_data.py
@@ -156,9 +156,9 @@ dmapDataTypes = {
 }
 
 dmapNames = {}
-for k in dmapCodeTypes.keys():
+for k in list(dmapCodeTypes.keys()):
     dmapNames[dmapCodeTypes[k][0]] = k
 
 dmapReverseDataTypes = {}
-for k in dmapDataTypes.keys():
+for k in list(dmapDataTypes.keys()):
     dmapReverseDataTypes[dmapDataTypes[k]] = k

--- a/spydaap/metadata.py
+++ b/spydaap/metadata.py
@@ -18,7 +18,7 @@ from hashlib import md5
 import os
 import struct
 import spydaap.cache
-import StringIO
+import io
 from spydaap.daap import do
 
 
@@ -63,7 +63,7 @@ class MetadataCacheItem(spydaap.cache.OrderedCacheItem):
 
     @classmethod
     def write_entry(self, dir, name, fn, daap):
-        if isinstance(name, unicode):
+        if isinstance(name, str):
             name = name.encode('utf-8')
         data = "".join([d.encode() for d in daap])
         data = struct.pack('!i%ss' % len(name), len(name), name) + data
@@ -115,7 +115,7 @@ class MetadataCacheItem(spydaap.cache.OrderedCacheItem):
     def get_md(self):
         if self.md is None:
             self.md = {}
-            s = StringIO.StringIO(self.get_dmap_raw())
+            s = io.StringIO(self.get_dmap_raw())
             l = len(self.get_dmap_raw())
             data = []
             while s.tell() != l:

--- a/spydaap/parser/__init__.py
+++ b/spydaap/parser/__init__.py
@@ -22,24 +22,24 @@ class Parser:
 
     def handle_string_tags(self, map, md, daap):
         h = {}
-        for k in md.tags.keys():
+        for k in list(md.tags.keys()):
             if k in map:
-                tag = [unicode(t) for t in md.tags[k]]
+                tag = [str(t) for t in md.tags[k]]
                 tag = [t for t in tag if t != ""]
                 if not(map[k] in h):
                     h[map[k]] = []
                 h[map[k]] = h[map[k]] + tag
-        for k in h.keys():
+        for k in list(h.keys()):
             h[k].sort()
             daap.append(do(k, "/".join(h[k])))
 
     def handle_int_tags(self, map, md, daap):
-        for k in md.tags.keys():
+        for k in list(md.tags.keys()):
             if k in map:
                 val = md.tags[k]
                 if isinstance(val, list):
                     val = val[0]
-                intval = self.my_int(unicode(val))
+                intval = self.my_int(str(val))
                 if intval:
                     daap.append(do(map[k], intval))
 
@@ -57,7 +57,7 @@ class Parser:
         return name
 
     def clean_int_string(self, s):
-        return re.sub(u'[^0-9]', '', unicode(s))
+        return re.sub('[^0-9]', '', str(s))
 
     def my_int(self, s):
         try:

--- a/spydaap/parser/vorbis.py
+++ b/spydaap/parser/vorbis.py
@@ -75,7 +75,7 @@ class VorbisParser(spydaap.parser.Parser):
         discnumber = None
         disccount = None
         if 'discnumber' in flac.tags:
-            t = unicode(flac.tags['discnumber'][0]).split('/')
+            t = str(flac.tags['discnumber'][0]).split('/')
             discnumber = self.my_int(t[0])
             if (len(t) == 2):
                 disccount = self.my_int(t[1])

--- a/spydaap/server.py
+++ b/spydaap/server.py
@@ -13,11 +13,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Spydaap. If not, see <http://www.gnu.org/licenses/>.
 
-import BaseHTTPServer
+import http.server
 import errno
 import os
 import re
-import urlparse
+import urllib.parse
 import socket
 import spydaap
 from spydaap.daap import do
@@ -26,7 +26,7 @@ from spydaap.daap import do
 def makeDAAPHandlerClass(server_name, cache, md_cache, container_cache):
     session_id = 1
 
-    class DAAPHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+    class DAAPHandler(http.server.BaseHTTPRequestHandler):
         daap_server_revision = 1
         protocol_version = "HTTP/1.1"
 
@@ -39,7 +39,7 @@ def makeDAAPHandlerClass(server_name, cache, md_cache, container_cache):
             self.send_header('Accept-Ranges', 'bytes')
             self.send_header('Content-Language', 'en_us')
             if 'extra_headers' in kwargs:
-                for k, v in kwargs['extra_headers'].iteritems():
+                for k, v in list(kwargs['extra_headers'].items()):
                     self.send_header(k, v)
             try:
                 if isinstance(data, file):
@@ -58,7 +58,8 @@ def makeDAAPHandlerClass(server_name, cache, md_cache, container_cache):
                             self.wfile.write(d)
                     else:
                         self.wfile.write(data)
-                except socket.error, (err_no, err_str):
+                except socket.error as xxx_todo_changeme:
+                    (err_no, err_str) = xxx_todo_changeme.args
                     if err_no in [errno.ECONNRESET]:
                         # XXX: why do we need to pass this?
                         pass
@@ -74,7 +75,7 @@ def makeDAAPHandlerClass(server_name, cache, md_cache, container_cache):
         drop_q = '(?:\\?.*)?$'
 
         def do_GET(self):
-            parsed_path = urlparse.urlparse(self.path).path
+            parsed_path = urllib.parse.urlparse(self.path).path
             if re.match(self.itunes_re + "/$", parsed_path):
                 self.do_GET_login()
             elif re.match(self.itunes_re + '/server-info$', parsed_path):
@@ -142,7 +143,7 @@ def makeDAAPHandlerClass(server_name, cache, md_cache, container_cache):
 
         def do_GET_content_codes(self):
             children = [do('dmap.status', 200)]
-            for code in spydaap.daap.dmapCodeTypes.keys():
+            for code in list(spydaap.daap.dmapCodeTypes.keys()):
                 (name, dtype) = spydaap.daap.dmapCodeTypes[code]
                 d = do('dmap.dictionary',
                        [do('dmap.contentcodesnumber', code),


### PR DESCRIPTION
I've gotten it about as far as I can figure at this point, but I think the logging function needs a rework to work properly under Python3:  
```
spydaap 
spydaap server started (use --help for more options).  Press Ctrl-C to exit.
Traceback (most recent call last):
  File "/usr/bin/spydaap", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.12/site-packages/spydaap/cli.py", line 207, in main
    really_main(opts)
  File "/usr/lib/python3.12/site-packages/spydaap/cli.py", line 99, in really_main
    rebuild_cache()
  File "/usr/lib/python3.12/site-packages/spydaap/cli.py", line 86, in rebuild_cache
    container_cache.build(md_cache)
  File "/usr/lib/python3.12/site-packages/spydaap/containers.py", line 43, in build
    entries = [n for n in md_cache if pl.contains(n)]
                          ^^^^^^^^
  File "/usr/lib/python3.12/site-packages/spydaap/cache.py", line 55, in __next__
    if self.n >= len(self.cache):
                 ^^^^^^^^^^^^^^^
TypeError: 'float' object cannot be interpreted as an integer
Exception ignored in: <spydaap.cli.logging object at 0x7f78283f2a80>
AttributeError: 'logging' object has no attribute 'flush'
Exception ignored in sys.unraisablehook: <built-in function unraisablehook>
AttributeError: 'logging' object has no attribute 'flush'
```
Hopefully this is somewhat helpful as a starting point to carry forward fixing up spydaap for Python3, and thus Exaile 4.x usage.